### PR TITLE
Fix typo in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ultimate ANSI colors for Golang. The package supports Printf/Sprintf etc.
 
 # TOC
 
-- [Insallation](#installation)
+- [Installation](#installation)
 - [Usage](#usage)
   + [Simple](#simple)
   + [Printf](#printf)


### PR DESCRIPTION
Noticed this when reading through the README. Thanks for the great project - switching some projects over from `fatih/color`