### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Methods `Index` and `BgIndex` implements 8-bit colors.
   + red
   + green
   + yellow (brown)
-  +  blue
+  + blue
   + magenta
   + cyan
   + white
@@ -295,7 +295,7 @@ The obvious workaround is `Red(fmt.Sprintf("%T", some))`
 The Aurora provides ANSI colors only, so there is no support for Windows. That said, there are workarounds available. 
 Check out these comments to learn more:
 
-- [Using go-colrable](https://github.com/logrusorgru/aurora/issues/2#issuecomment-299014211).
+- [Using go-colorable](https://github.com/logrusorgru/aurora/issues/2#issuecomment-299014211).
 - [Using registry for Windows 10](https://github.com/logrusorgru/aurora/issues/10#issue-476361247).
 
 ### TTY


### PR DESCRIPTION
 go-colrable -> go-colorable