### PR TITLE
add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/logrusorgru/aurora/v2
+
+go 1.14


### PR DESCRIPTION
This PR adds a `go.mod` file declaring the module as `github.com/logrusorgru/aurora/v2` to match the latest v2.x.x tags.

The intent is for this package to not appear marked as "incompatible" in projects that have a dependency on it, for example:
```
	github.com/logrusorgru/aurora v2.0.3+incompatible
```

Let me know what you think about this change.