### PR TITLE
Adds support for Hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,24 @@ func main() {
 }
 ```
 
+# Hyperlinks
+
+Many modern terminal emulators support [hyperlinking arbitrary text](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#supporting-apps)
+in a backward-compatible fashion. Aurora provides an interface for printing them:
+
+```go
+package main
+
+import (
+  "fmt"
+  "github.com/logrusorgru/aurora"
+)
+
+func main() {
+  fmt.Println("Now with ", aurora.Link("links", "https://github.com/logrusorgru/aurora"))
+}
+```
+
 # Supported colors & formats
 
 - formats
@@ -281,6 +299,8 @@ func main() {
   + white
   + 24 grayscale colors
   + 216 8-bit colors
+- special formatting
+  + hyperlinks
 
 ### All colors
 

--- a/color.go
+++ b/color.go
@@ -180,6 +180,8 @@ const (
 	availFlags = "-+# 0"
 	esc        = "\033["
 	clear      = esc + "0m"
+	oscURL     = "\033]8;;"
+	st         = "\033\\"
 )
 
 // IsValid returns true always

--- a/value_test.go
+++ b/value_test.go
@@ -43,11 +43,11 @@ import (
 func TestValue_String(t *testing.T) {
 	var v Value
 	// colorized
-	v = value{"x", 0, 0}
+	v = value{"x", 0, 0, ""}
 	if x := v.String(); x != "x" {
 		t.Errorf("(value).String: want %q, got %q", "x", x)
 	}
-	v = value{"x", BlackFg, RedBg}
+	v = value{"x", BlackFg, RedBg, ""}
 	want := "\033[0;30mx\033[0;41m"
 	if got := v.String(); want != got {
 		t.Errorf("(value).String: want %q, got %q", want, got)
@@ -62,7 +62,7 @@ func TestValue_String(t *testing.T) {
 
 func TestValue_Color(t *testing.T) {
 	// colorized
-	if (value{"", RedFg, 0}).Color() != RedFg {
+	if (value{"", RedFg, 0, ""}).Color() != RedFg {
 		t.Error("wrong color")
 	}
 	// clear
@@ -73,7 +73,7 @@ func TestValue_Color(t *testing.T) {
 
 func TestValue_Value(t *testing.T) {
 	// colorized
-	if (value{"x", RedFg, BlueBg}).Value() != "x" {
+	if (value{"x", RedFg, BlueBg, ""}).Value() != "x" {
 		t.Error("wrong value")
 	}
 	// clear
@@ -84,7 +84,7 @@ func TestValue_Value(t *testing.T) {
 
 func TestValue_Bleach(t *testing.T) {
 	// colorized
-	if (value{"x", RedFg, BlueBg}).Bleach() != (value{value: "x"}) {
+	if (value{"x", RedFg, BlueBg, ""}).Bleach() != (value{value: "x"}) {
 		t.Error("wrong bleached")
 	}
 	// clear
@@ -99,7 +99,7 @@ func TestValue_Format(t *testing.T) {
 	//
 	// colorized
 	//
-	v = value{3.14, RedFg, BlueBg}
+	v = value{3.14, RedFg, BlueBg, ""}
 	got = fmt.Sprintf("%+1.3g", v)
 	want = "\033[0;31m" + fmt.Sprintf("%+1.3g", 3.14) + "\033[0;44m"
 	if want != got {
@@ -129,9 +129,42 @@ func TestValue_Format(t *testing.T) {
 	}
 }
 
+// As documented at https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+func TestValue_Link(t *testing.T) {
+	var v Value
+	var want, got string
+	//
+	// linked
+	//
+	v = value{"example site", 0, 0, "http://example.com"}
+	got = fmt.Sprintf("%s", v)
+	want = "\033]8;;" + "http://example.com" + "\033\\" + "example site" + "\033]8;;\033\\"
+	if want != got {
+		t.Errorf("Format: want %q, got %q", want, got)
+	}
+	//
+	// reset
+	//
+	v = value{"example site", 0, 0, "http://example.com"}
+	got = fmt.Sprintf("%s", v.Reset())
+	want = "example site"
+	if want != got {
+		t.Errorf("Format: want %q, got %q", want, got)
+	}
+	//
+	// linked & coloured
+	//
+	v = value{"example site", RedFg, BlueBg, "http://example.com"}
+	got = fmt.Sprintf("%s", v)
+	want = "\033[0;31m" + "\033]8;;" + "http://example.com" + "\033\\" + "example site" + "\033]8;;\033\\" + "\033[0;44m"
+	if want != got {
+		t.Errorf("Format: want %q, got %q", want, got)
+	}
+}
+
 func Test_tail(t *testing.T) {
 	// colorized
-	if (value{"x", 0, BlueBg}).tail() != BlueBg {
+	if (value{"x", 0, BlueBg, ""}).tail() != BlueBg {
 		t.Error("wrong tail color")
 	}
 	// clear
@@ -142,7 +175,7 @@ func Test_tail(t *testing.T) {
 
 func Test_setTail(t *testing.T) {
 	// colorized
-	if (value{"x", 0, 0}).setTail(RedFg) != (value{"x", 0, RedFg}) {
+	if (value{"x", 0, 0, ""}).setTail(RedFg) != (value{"x", 0, RedFg, ""}) {
 		t.Error("wrong setTail behavior")
 	}
 	// clear

--- a/value_test.go
+++ b/value_test.go
@@ -143,6 +143,24 @@ func TestValue_Link(t *testing.T) {
 		t.Errorf("Format: want %q, got %q", want, got)
 	}
 	//
+	// applying link
+	//
+	v = value{"example site", 0, 0, ""}.Link("http://example.com")
+	got = fmt.Sprintf("%s", v)
+	want = "\033]8;;" + "http://example.com" + "\033\\" + "example site" + "\033]8;;\033\\"
+	if want != got {
+		t.Errorf("Format: want %q, got %q", want, got)
+	}
+	//
+	// clear
+	//
+	v = valueClear{"example site"}.Link("http://example.com")
+	got = fmt.Sprintf("%s", v)
+	want = "example site"
+	if want != got {
+		t.Errorf("Format: want %q, got %q", want, got)
+	}
+	//
 	// reset
 	//
 	v = value{"example site", 0, 0, "http://example.com"}

--- a/wrap.go
+++ b/wrap.go
@@ -53,7 +53,7 @@ func Colorize(arg interface{}, color Color) Value {
 		val.color = color
 		return val
 	}
-	return value{arg, color, 0}
+	return value{arg, color, 0, ""}
 }
 
 // Reset wraps given argument returning Value
@@ -555,4 +555,11 @@ func BgGray(n uint8, arg interface{}) Value {
 		n = 23
 	}
 	return value{value: arg, color: (Color(n+232) << shiftBg) | flagBg}
+}
+
+func Link(arg interface{}, url string) Value {
+	if val, ok := arg.(Value); ok {
+		return val.Link(url)
+	}
+	return value{value: arg, linkURL: url}
 }

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -408,3 +408,11 @@ func Test_bigGray(t *testing.T) {
 	testFunc(t, "Gray", Gray(115, "x"), Color(232+23)<<shiftFg|flagFg)
 	testFunc(t, "BgGray", BgGray(215, "x"), Color(232+23)<<shiftBg|flagBg)
 }
+
+func Test_Link(t *testing.T) {
+	got := Link("text", "http://example.com")
+	want := value{value: "text", linkURL: "http://example.com"}
+	if got != want {
+		t.Errorf("want = %+v got = %+v", want, got)
+	}
+}

--- a/wrap_test.go
+++ b/wrap_test.go
@@ -415,4 +415,9 @@ func Test_Link(t *testing.T) {
 	if got != want {
 		t.Errorf("want = %+v got = %+v", want, got)
 	}
+
+	got = Link(value{value: "text"}, "http://example.com")
+	if got != want {
+		t.Errorf("want = %+v got = %+v", want, got)
+	}
 }


### PR DESCRIPTION
Adds support for Hyperlinks in many modern terminal emulators, as described in [this gist](https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#supporting-apps).

```go
package main

import (
  "fmt"
  "github.com/logrusorgru/aurora"
)

func main() {
  fmt.Println("Now with ", aurora.Link("links", "https://github.com/logrusorgru/aurora"))
}
```